### PR TITLE
Adding notifications_enabled attribute to users and post owner notifications of comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ It has been heavely inspired by [Canny.io](https://canny.io/) ("astuto", indeed,
 * Boards, to divide different types of feedback
 * Roadmap, to let your users know what you're working on
 * Comments, to discuss with your customers
+* Notifications, to inform post owner of comments
 * Feedback labels, to inform about the state of a certain feedback
 * Feedback updates, to notify your users with news regarding a certain feedback
 * Completely customizable (i.e. you can add/edit/remove as many boards, feedback statuses as you want; you can configure the roadmap the way you want; etc.)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,8 +5,8 @@ class ApplicationController < ActionController::Base
   protected
 
     def configure_permitted_parameters
-      devise_parameter_sanitizer.permit(:sign_up, keys: [:full_name])
-      devise_parameter_sanitizer.permit(:account_update, keys: [:full_name])
+      devise_parameter_sanitizer.permit(:sign_up, keys: [:full_name, :notifications_enabled])
+      devise_parameter_sanitizer.permit(:account_update, keys: [:full_name, :notifications_enabled])
     end
 
     def load_boards

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,0 +1,10 @@
+class UserMailer < ApplicationMailer
+  default from: "notifications@example.com"
+
+  def notify_post_owner(comment:)
+    @comment = comment
+    @user = comment.post.user
+
+    mail(to: @user.email, subject: "[#{ENV.fetch('APP_NAME')}] - New comment on #{comment.post.title}")
+  end
+end

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -16,6 +16,11 @@
     </small>
   </div>
 
+  <div class="form-group">
+    <%= f.label :notifications_enabled %>
+    <%= f.check_box :notifications_enabled %>
+  </div>
+
   <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
     <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
   <% end %>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -7,7 +7,7 @@
     <%= f.label :full_name, class: "sr-only" %>
     <%= f.text_field :full_name, autofocus: true, placeholder: "Full name", required: true, class: "form-control" %>
   </div>
-  
+
   <div class="form-group">
     <%= f.label :email, class: "sr-only" %>
     <%= f.email_field :email, autocomplete: "email", placeholder: "Email address", required: true, class: "form-control" %>
@@ -21,6 +21,11 @@
   <div class="form-group">
     <%= f.label :password_confirmation, class: "sr-only" %>
     <%= f.password_field :password_confirmation, placeholder: "Password confirmation", required: true, class: "form-control" %>
+  </div>
+
+  <div class="form-group">
+    <%= f.label :notifications_enabled %>
+    <%= f.check_box :notifications_enabled %>
   </div>
 
   <div class="actions">

--- a/app/views/user_mailer/notify_post_owner.html.erb
+++ b/app/views/user_mailer/notify_post_owner.html.erb
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
+  </head>
+  <body>
+    <h1>Hello, <%= @user.full_name %></h1>
+    <p>
+      There is a new comment by <%= @comment.user.full_name %> on your post <b><%= @comment.post.title %></b>
+    </p>
+    <p> To see this comment, <%= link_to "Click here", post_url(@comment.post) %> </p>
+    <p>Have a great day!</p>
+  </body>
+  <footer>
+    Annoyed ? You can <%= link_to("turn off notifications here", edit_user_registration_url) %>
+  </footer>
+</html>

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -9,7 +9,6 @@ ENV["POSTS_PER_PAGE"] = "15"
 
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
-  
   # For Devise
   config.action_mailer.default_url_options = { host: 'localhost:3000' }
 
@@ -46,6 +45,7 @@ Rails.application.configure do
   # The :test delivery method accumulates sent emails in the
   # ActionMailer::Base.deliveries array.
   config.action_mailer.delivery_method = :test
+  config.active_job.queue_adapter = :test
 
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr

--- a/db/migrate/20210126215831_add_notifications_enabled_field_to_users.rb
+++ b/db/migrate/20210126215831_add_notifications_enabled_field_to_users.rb
@@ -1,0 +1,5 @@
+class AddNotificationsEnabledFieldToUsers < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :notifications_enabled, :boolean, null: false, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_01_160859) do
+ActiveRecord::Schema.define(version: 2021_01_26_215831) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -84,6 +84,7 @@ ActiveRecord::Schema.define(version: 2019_10_01_160859) do
     t.datetime "updated_at", precision: 6, null: false
     t.integer "role"
     t.string "full_name"
+    t.boolean "notifications_enabled", default: true, null: false
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,14 +1,15 @@
 FactoryBot.define do
   factory :user do
     sequence(:email) { |n| "user#{n}@example.com" }
-    
+
     full_name { 'First Last' }
+    notifications_enabled { true }
     password { 'password' }
   end
 
   factory :moderator, class: User do
     sequence(:email) { |n| "mod#{n}@example.com" }
-    
+
     full_name { 'First Last' }
     password { 'password' }
     role { 'moderator' }
@@ -16,7 +17,7 @@ FactoryBot.define do
 
   factory :admin, class: User do
     sequence(:email) { |n| "admin#{n}@example.com" }
-    
+
     full_name { 'First Last' }
     password { 'password' }
     role { 'admin' }

--- a/spec/mailers/previews/user_mailer_preview.rb
+++ b/spec/mailers/previews/user_mailer_preview.rb
@@ -1,0 +1,6 @@
+# Preview all emails at http://localhost:3000/rails/mailers/user_mailer
+class UserMailerPreview < ActionMailer::Preview
+  def notify_post_owner
+    UserMailer.notify_post_owner(comment: Comment.first)
+  end
+end

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+
+RSpec.describe UserMailer, type: :mailer do
+  describe "notify_comment" do
+    let(:user) { FactoryBot.create(:user, email: "notified@example.com", notifications_enabled: true) }
+    let(:post) { FactoryBot.create(:post, user: user)}
+    let(:comment) { FactoryBot.create(:comment, post: post) }
+    let(:mail) { UserMailer.notify_post_owner(comment: comment) }
+
+    it "renders the headers" do
+      expect(mail.subject).to eq("[#{ENV.fetch('APP_NAME')}] - New comment on #{post.title}")
+      expect(mail.to).to eq(["notified@example.com"])
+      expect(mail.from).to eq(["notifications@example.com"])
+    end
+
+    it "renders the body" do
+      expect(mail.body.encoded).to include("Hello, #{user.full_name}")
+      expect(mail.body.encoded).to include("There is a new comment by")
+      expect(mail.body.encoded).to include('Annoyed ? You can <a href="http://localhost:3000/users/edit">turn off notifications here</a>')
+    end
+  end
+end

--- a/spec/support/action_mailer.rb
+++ b/spec/support/action_mailer.rb
@@ -1,0 +1,5 @@
+RSpec.configure do |config|
+  config.before(:each) do
+    ActionMailer::Base.deliveries.clear
+  end
+end

--- a/spec/system/user_edit_profile_spec.rb
+++ b/spec/system/user_edit_profile_spec.rb
@@ -4,10 +4,10 @@ require 'rails_helper'
 feature 'edit user profile settings', type: :system do
   let(:user) { FactoryBot.create(:user) }
 
-  before(:each) do 
+  before(:each) do
     user.confirm # devise helper to confirm user account
     sign_in user # devise helper to login user
-    
+
     # check that user is confirmed and saved in the db
     expect(user.confirmed_at).not_to be_nil
     expect(User.count).to eq(1)
@@ -42,6 +42,30 @@ feature 'edit user profile settings', type: :system do
     user.confirm
     expect(user.email).to eq(new_email)
     expect(page).to have_css('.notice')
+  end
+
+  scenario 'turns on notifications' do
+    user.update(notifications_enabled: false)
+
+    visit edit_user_registration_path
+    check 'Notifications enabled'
+    fill_in 'Current password', with: user.password
+    click_button 'Update profile'
+
+    user.reload
+    expect(user.notifications_enabled).to eq(true)
+  end
+
+  scenario 'turns off notifications' do
+    user.update(notifications_enabled: user)
+
+    visit edit_user_registration_path
+    uncheck 'Notifications enabled'
+    fill_in 'Current password', with: user.password
+    click_button 'Update profile'
+
+    user.reload
+    expect(user.notifications_enabled).to eq(false)
   end
 
   # Remember that 'password' is just a virtual attribute (i.e. it is not stored in the db)
@@ -91,7 +115,7 @@ feature 'edit user profile settings', type: :system do
     visit edit_user_registration_path
     click_button 'Cancel my account'
     page.driver.browser.switch_to.alert.accept # accepts js pop up
-    
+
     expect(page).to have_current_path(root_path)
     expect(User.count).to eq(user_count - 1)
     expect(page).to have_css('.notice')

--- a/spec/system/user_sign_up_spec.rb
+++ b/spec/system/user_sign_up_spec.rb
@@ -9,6 +9,7 @@ feature 'sign up', type: :system do
     fill_in 'Email', with: user.email
     fill_in 'Password', with: user.password
     fill_in 'Password confirmation', with: user.password
+    check 'Notifications enabled'
     click_button 'Sign up'
   end
 
@@ -19,14 +20,14 @@ feature 'sign up', type: :system do
 
   scenario 'with valid fields' do
     user_count = User.count
-    
+
     sign_up_as user
-    
+
     expect(User.count).to eq(user_count + 1)
     expect(page).to have_current_path(root_path)
     expect(page).to have_css('.notice')
   end
-  
+
   scenario 'with invalid Full Name' do
     user_count = User.count
 
@@ -74,5 +75,17 @@ feature 'sign up', type: :system do
     expect(User.count).to eq(user_count)
     expect_to_be_on_sign_up_page
     expect(page).to have_css('.alert')
+  end
+
+  scenario 'and disables notifications' do
+    visit new_user_registration_path
+    fill_in 'Full name', with: user.full_name
+    fill_in 'Email', with: user.email
+    fill_in 'Password', with: user.password
+    fill_in 'Password confirmation', with: user.password
+    uncheck 'Notifications enabled'
+    click_button 'Sign up'
+
+    expect(User.last.notifications_enabled).to eq(false)
   end
 end

--- a/spec/system/user_sign_up_spec.rb
+++ b/spec/system/user_sign_up_spec.rb
@@ -77,7 +77,7 @@ feature 'sign up', type: :system do
     expect(page).to have_css('.alert')
   end
 
-  scenario 'and disables notifications' do
+  scenario 'with disabled notifications' do
     visit new_user_registration_path
     fill_in 'Full name', with: user.full_name
     fill_in 'Email', with: user.email


### PR DESCRIPTION
This diff adds an attribute (defaulted to true) for notifications.

A user can now, on sign_up or in his profile, decide to receive or not notifications. 
User will be notified of new comments on their posts.

Refers to [This Project Card](https://github.com/riggraz/astuto/projects/1#card-31194036) and #42 