### PR TITLE
Fix user password change bug

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,7 +12,8 @@ class User < ApplicationRecord
 
   after_initialize :set_default_role, if: :new_record?
   after_initialize :set_default_status, if: :new_record?
-  after_initialize :skip_confirmation, if: :new_record?
+
+  before_save :skip_confirmation
 
   validates :full_name, presence: true, length: { in: 2..32 }
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -64,7 +64,7 @@ Rails.application.configure do
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
-  # config.action_mailer.raise_delivery_errors = false
+  config.action_mailer.raise_delivery_errors = false
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).


### PR DESCRIPTION
This PR fixes issue #62

We temporarely disable error raising in production mode if emails aren't getting delivered. In the future we'll add some ENV variables to properly configure email servers and then, maybe, add the error rasing again.